### PR TITLE
Fix error due to unit field in spec files not beeing a string but a dictionary or list

### DIFF
--- a/resol.py
+++ b/resol.py
@@ -161,11 +161,16 @@ def parse_payload(msg):
                 packet['command'].lower() == get_command(msg).lower():
             result[get_source_name(msg)] = {}
             for field in packet['field']:
-                result[get_source_name(msg)][field['name'][0]] = str(
-                    gb(payload, field['offset'], int(field['offset'])+((int(field['bitSize'])+1) / 8)) *
-                    (Decimal(field['factor']) if 'factor' in field else 1)) + \
-                    (field['unit'] if 'unit' in field and config.use_units else '')
-
+                result[get_source_name(msg)][field['name']] = \
+                    str(
+                        gb(payload, field['offset'], int(field['offset'])+((int(field['bitSize'])+1) / 8)) *
+                        (Decimal(field['factor']) if 'factor' in field else 1)
+                    ) + \
+                    (field['unit']
+                        if config.use_units
+                        and 'unit' in field
+                        and isinstance(field['unit'], str)
+                     else '')
 
 def format_message_pv1(msg):
     parsed = "PARSED: \n"


### PR DESCRIPTION
Just a small change to prevent an error that might only occur due to a bad xml->json conversion but makes the script more failsafe