### PR TITLE
Fix field name extraction in parse_payload to handle list types

### DIFF
--- a/resol.py
+++ b/resol.py
@@ -161,7 +161,9 @@ def parse_payload(msg):
                 packet['command'].lower() == get_command(msg).lower():
             result[get_source_name(msg)] = {}
             for field in packet['field']:
-                result[get_source_name(msg)][field['name']] = \
+                # extract field name as string, as it might be a list and newer Pythons need a string
+                field_name = field['name'][0] if isinstance(field['name'], list) else field['name']
+                result[get_source_name(msg)][field_name] = \
                     str(
                         gb(payload, field['offset'], int(field['offset'])+((int(field['bitSize'])+1) / 8)) *
                         (Decimal(field['factor']) if 'factor' in field else 1)


### PR DESCRIPTION
With my current Python 3.13 I get an error
```
  File "resol-vbus-python/resol.py", line 164, in parse_payload
    result[get_source_name(msg)][field['name']] = \
    ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^
TypeError: unhashable type: 'list'
```
as spec file can be
```
       "field": [
          {
            "offset": "0",
            "name": [
              "Temperatur Sensor 1",
              {
                "-lang": "en",
                "#text": "Temperature sensor 1"
              }
            ],
            "bitSize": "15",
            "factor": "0.1",
            "unit": " °C"
          },
```
or
```
        "field": [
          {
            "-commonUsage": "'collector1'",
            "offset": "0",
            "name": "Temperatur Sensor 1",
            "bitSize": "15",
            "factor": "0.1",
            "unit": " \\u00b0C"
          },
```
